### PR TITLE
Update mediaInfo.js

### DIFF
--- a/lib/mediaInfo.js
+++ b/lib/mediaInfo.js
@@ -174,7 +174,7 @@ module.exports = function (logClass) {
         if ("icy-name" in res.headers)
           title = res.headers["icy-name"];
 
-        that._addItem (that._url, that._contentType, {title: title});
+        that._addItem (that._url, that._contentType, {albumName: title});
 
         // log any "metadata" events that happen
         res.on('metadata', that._gotMetadata.bind(that, res));


### PR DESCRIPTION
Der Sendername von Webradios wird vom aktuell gespielten Lied im title Objekt immer überschrieben, daher wird der Sendername nun im Album gespeichert, sofern er im icy-name header übermittelt wird.